### PR TITLE
refactor: 엔티티 기본값 초기화 방식을 DB 기본값으로 통일

### DIFF
--- a/src/main/java/org/umc/spring/domain/Comment.java
+++ b/src/main/java/org/umc/spring/domain/Comment.java
@@ -2,6 +2,7 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
 import org.umc.spring.domain.common.BaseEntity;
 import org.umc.spring.domain.enums.CommentStatus;
 
@@ -10,6 +11,7 @@ import org.umc.spring.domain.enums.CommentStatus;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
 public class Comment extends BaseEntity {
 
     @Id
@@ -33,12 +35,5 @@ public class Comment extends BaseEntity {
             this.review.getComments().remove(this);
         }
         this.review = review;
-    }
-
-    @PrePersist
-    private void prePersist() {
-        if (this.status == null) {
-            this.status = CommentStatus.ACTIVE;
-        }
     }
 }

--- a/src/main/java/org/umc/spring/domain/Member.java
+++ b/src/main/java/org/umc/spring/domain/Member.java
@@ -2,6 +2,8 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.umc.spring.domain.common.BaseEntity;
 import org.umc.spring.domain.enums.Gender;
 import org.umc.spring.domain.enums.MemberStatus;
@@ -20,6 +22,8 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
 public class Member extends BaseEntity {
 
     @Id
@@ -27,7 +31,6 @@ public class Member extends BaseEntity {
     private Long id;
 
     @Version
-    @Builder.Default
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long version = 0L;
 
@@ -79,7 +82,6 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String password;
 
-    @Builder.Default
     @Column(nullable = false, length = 20)
     private Integer point = 0;
 
@@ -145,14 +147,4 @@ public class Member extends BaseEntity {
         review.setMember(null);
     }
 
-
-    @PrePersist
-    private void prePersist() {
-        if (this.point == null) {
-            this.point = 0;
-        }
-        if (this.status == null) {
-            this.status = MemberStatus.ACTIVE;
-        }
-    }
 }

--- a/src/main/java/org/umc/spring/domain/Mission.java
+++ b/src/main/java/org/umc/spring/domain/Mission.java
@@ -2,6 +2,8 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.umc.spring.domain.common.BaseEntity;
 import org.umc.spring.domain.mapping.MemberMission;
 
@@ -14,6 +16,8 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
 public class Mission extends BaseEntity {
 
     @Id

--- a/src/main/java/org/umc/spring/domain/Review.java
+++ b/src/main/java/org/umc/spring/domain/Review.java
@@ -2,6 +2,8 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.umc.spring.domain.common.BaseEntity;
 import org.umc.spring.domain.enums.ReviewStatus;
 
@@ -15,6 +17,8 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
 public class Review extends BaseEntity {
 
     @Id
@@ -49,7 +53,6 @@ public class Review extends BaseEntity {
     private ReviewStatus status;
 
     @Version
-    @Builder.Default
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long version = 0L;
 
@@ -89,12 +92,5 @@ public class Review extends BaseEntity {
             this.member.getReviews().remove(this);
         }
         this.member = member;
-    }
-
-    @PrePersist
-    private void prePersist() {
-        if (this.status == null) {
-            this.status = ReviewStatus.ACTIVE;
-        }
     }
 }

--- a/src/main/java/org/umc/spring/domain/Store.java
+++ b/src/main/java/org/umc/spring/domain/Store.java
@@ -2,6 +2,8 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.umc.spring.domain.common.BaseEntity;
 
 import java.time.DayOfWeek;
@@ -14,6 +16,8 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
 public class Store extends BaseEntity {
 
     @Id
@@ -21,7 +25,6 @@ public class Store extends BaseEntity {
     private Long id;
 
     @Version
-    @Builder.Default
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long version = 0L;
 
@@ -74,16 +77,6 @@ public class Store extends BaseEntity {
             this.region.getStores().remove(this);
         }
         this.region = region;
-    }
-
-    @PrePersist
-    private void prePersist() {
-        if (this.openTime == null) {
-            this.openTime = LocalTime.of(8, 0);
-        }
-        if (this.closeTime == null) {
-            this.closeTime = LocalTime.of(23, 59);
-        }
     }
 
     @Override

--- a/src/main/java/org/umc/spring/domain/Terms.java
+++ b/src/main/java/org/umc/spring/domain/Terms.java
@@ -2,6 +2,7 @@ package org.umc.spring.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
 import org.umc.spring.domain.common.BaseEntity;
 import org.umc.spring.domain.mapping.MemberAgree;
 
@@ -13,6 +14,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
 public class Terms extends BaseEntity {
 
     @Id
@@ -43,12 +45,5 @@ public class Terms extends BaseEntity {
         if (memberAgree == null || !this.memberAgrees.contains(memberAgree)) return;
         this.memberAgrees.remove(memberAgree);
         memberAgree.setTerms(null);
-    }
-
-    @PrePersist
-    private void prePersist() {
-        if (this.optional == null) {
-            this.optional = false;
-        }
     }
 }


### PR DESCRIPTION
- 기존의 코드는 DB 기본값, Java 기본값 초기화가 혼용되는 문제가 있었음
- @DynamicInsert, @DynamicUpdate는 성능 영향을 고려해 필요한 엔티티에만 선택적 적용
- @PrePersist, @Builder.Default 제거
- 예외적으로 Collection 필드는 Java 기본값 설정
- 이를 통해 충돌 방지 및 직접 SQL 실행 시 기본값 적용 보장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - 엔티티 클래스에 Hibernate의 동적 SQL 생성을 위한 `@DynamicInsert` 및 `@DynamicUpdate` 어노테이션이 추가되었습니다.
    - 엔티티의 기본값 설정을 담당하던 라이프사이클 콜백 메서드(`@PrePersist`)가 제거되었습니다.
    - 일부 필드의 어노테이션이 정리되고, 기본값 처리가 데이터베이스 기본값에 의존하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->